### PR TITLE
Differentiate cache hit of null vs not present

### DIFF
--- a/library/src/main/java/com/evernote/android/state/StateSaver.java
+++ b/library/src/main/java/com/evernote/android/state/StateSaver.java
@@ -35,7 +35,7 @@ public final class StateSaver {
     private static Injector getInjector(Class<?> cls)
             throws IllegalAccessException, InstantiationException {
         Injector injector = INJECTORS.get(cls);
-        if (injector != null) {
+        if (injector != null || INJECTORS.contains(cls)) {
             return injector;
         }
         String clsName = cls.getName();


### PR DESCRIPTION
This is an optimization that was also added to Icepick https://github.com/frankiesardo/icepick/issues/96 that I suggested there.

This approach is slightly different, but more efficient than how Icepick solved it.