### PR TITLE
Problem with inner class and generics when using kapt

### DIFF
--- a/library/src/test/java/com/evernote/android/state/test/TestInnerClassGeneric.java
+++ b/library/src/test/java/com/evernote/android/state/test/TestInnerClassGeneric.java
@@ -1,0 +1,10 @@
+package com.evernote.android.state.test;
+
+import com.evernote.android.state.State;
+
+public class TestInnerClassGeneric<P> {
+
+    public class Inner {
+        @State int field;
+    }
+}


### PR DESCRIPTION
A while ago, I've got a problem with inner classes when using kapt (issue #42).
That problem was fixed, but now I run into similar problem. When the top level class has generic type, generated StateSaver class looks like this:
`TestInnerClassGeneric$Inner$$StateSaver<T extends TestInnerClassGeneric<P>.Inner>`
Notice that `<P>` which should not be here.

As well as #42, it's ok when using `annotationProcessor`.

I've created a test class reproducing that problem.