### PR TITLE
Sort elements by name rather than type

### DIFF
--- a/processor/src/main/java/com/evernote/android/state/StateProcessor.java
+++ b/processor/src/main/java/com/evernote/android/state/StateProcessor.java
@@ -111,7 +111,7 @@ public class StateProcessor extends AbstractProcessor {
     private static final Comparator<Element> COMPARATOR = new Comparator<Element>() {
         @Override
         public int compare(Element o1, Element o2) {
-            return o1.asType().toString().compareTo(o2.asType().toString());
+            return o1.getSimpleName().toString().compareTo(o2.getSimpleName().toString());
         }
     };
 


### PR DESCRIPTION
The fields accessed by the processor have no guaranteed ordering, which I assume is why `fields` is sorted by type in the first place. In incremental builds, the order seems to change randomly, and this hurts compilation avoidance as then the generated StateSaver classes are different (calls shifted around but functionally not changing).
Since `fields` is being sorted by type, fields of the same type still have no guaranteed ordering. This changes them to be sorted by their name rather than their type. I can't think of any problems with sorting them by name, as field names have to be unique within a class.
Tested in a large project and a sample project. Thanks for the well-organized project, by the way.