### PR TITLE
Change android dependency to compileOnly

### DIFF
--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.squareup:javapoet:1.11.0'
 
     implementation 'com.google.auto.service:auto-service:1.0-rc4'
-    implementation 'com.google.android:android:4.1.1.4'
+    compileOnly 'com.google.android:android:4.1.1.4'
 
     implementation files('../library/build/intermediates/packaged-classes/release/classes.jar')
 


### PR DESCRIPTION
Fixes https://github.com/evernote/android-state/issues/56
Users of library will have android dependencies in a runtime as they use android project. 